### PR TITLE
Add 'web' to PLATFORM env var

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -82,6 +82,7 @@ function getClientEnvironment(publicUrl) {
         // This should only be used as an escape hatch. Normally you would put
         // images into the `src` and `import` them in code to get their paths.
         PUBLIC_URL: publicUrl,
+        PLATFORM: 'web',
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin


### PR DESCRIPTION
Some saga code should only be run in the context of `web`. When react-native is using the same sagas they should not execute web specific code.

This PR re-introduces the `PLATFORM` env var that we had before moving over to CRA. Setting this to `web` will re-enable the Google Tag Manager portions of the app that are currently not running and should be.

Fixes #24