### PR TITLE
Added jest extension to the testMatch regex

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -26,7 +26,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}',
-      '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}',
+      '<rootDir>/src/**/?(*.)(spec|test|jest).{js,jsx,mjs}',
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',


### PR DESCRIPTION
We have several tests in the webapp codebase with the `*.jest.js` extension but they are being ignored because they don't match current `testMatch` regex.