### PR TITLE
Ignore core tests when running jest in web app

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-home/react-scripts",
-  "version": "1.1.4-1",
+  "version": "1.1.4-2",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -55,6 +55,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
       'node',
       'mjs',
     ],
+    modulePathIgnorePatterns: ["<rootDir>/src/core/*"],
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
Core tests are failing in web now, possibly due to a different jest version or some differences in config - either way it feels redundant to run them twice.