### PR TITLE
add postcss plugin to reenable the color function

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -105,6 +105,7 @@ module.exports = function(webpackEnv) {
           ident: 'postcss',
           plugins: () => [
             require('postcss-flexbugs-fixes'),
+            require('postcss-color-mod-function'),
             require('postcss-preset-env')({
               autoprefixer: {
                 flexbox: 'no-2009',
@@ -561,7 +562,9 @@ module.exports = function(webpackEnv) {
         Object.assign({}, env.stringified, {
           // Currently builds may run in both travis and jenkins env
           'process.env.BUILD_NUMBER': JSON.stringify(
-            process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER || '----'
+            process.env.TRAVIS_BUILD_NUMBER ||
+              process.env.BUILD_NUMBER ||
+              '----'
           ),
           'process.locales': JSON.stringify(locales),
         })

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -24,8 +24,8 @@
   },
   "types": "./lib/react-app.d.ts",
   "dependencies": {
-    "@connected-home/hivehome-webapp-favicons-webpack-plugin": "^3.0.0",
     "@babel/core": "7.4.3",
+    "@connected-home/hivehome-webapp-favicons-webpack-plugin": "^3.0.0",
     "@svgr/webpack": "4.1.0",
     "@typescript-eslint/eslint-plugin": "1.6.0",
     "@typescript-eslint/parser": "1.6.0",
@@ -60,7 +60,7 @@
     "pnp-webpack-plugin": "1.2.1",
     "postcss-flexbugs-fixes": "4.1.0",
     "postcss-loader": "3.0.0",
-    "postcss-normalize": "7.0.1",   
+    "postcss-normalize": "7.0.1",
     "postcss-preset-env": "6.6.0",
     "postcss-safe-parser": "4.0.1",
     "react-app-polyfill": "^0.2.2",
@@ -76,6 +76,7 @@
     "workbox-webpack-plugin": "4.2.0"
   },
   "devDependencies": {
+    "postcss-color-mod-function": "^3.0.3",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },


### PR DESCRIPTION
Adding the `postcss-color-mod-function` to fix the color function from web, otherwise it doesn't get parsed and fails silently.

Corresponding PR here: https://github.com/ConnectedHomes/hivehome-webapp-v3/pull/5567