### PR TITLE
Remove postcss-color-mod plugin and use the built in postcss-preset-env

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -105,10 +105,12 @@ module.exports = function(webpackEnv) {
           ident: 'postcss',
           plugins: () => [
             require('postcss-flexbugs-fixes'),
-            require('postcss-color-mod-function'),
             require('postcss-preset-env')({
               autoprefixer: {
                 flexbox: 'no-2009',
+              },
+              features: {
+                'color-mod-function': { unresolved: 'ignore' },
               },
               stage: 3,
             }),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -76,7 +76,6 @@
     "workbox-webpack-plugin": "4.2.0"
   },
   "devDependencies": {
-    "postcss-color-mod-function": "^3.0.3",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-home/react-scripts",
-  "version": "2.1.8-6",
+  "version": "2.1.8-7",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebook/create-react-app",
   "license": "MIT",


### PR DESCRIPTION
Turns out `postcss-preset-env` already includes the `postcss-color-mod` plugin, so I turned it on in there. Also, during build the variables are not yet parsed when the color-mod plugin kicks in, I tried to move it at the end of the postcss loaders but with no luck. 

This took already too much time, so the above seems to fix it for now.
